### PR TITLE
Potential fix for code scanning alert no. 2: Disabled TLS certificate check

### DIFF
--- a/api/dns.go
+++ b/api/dns.go
@@ -146,7 +146,19 @@ func SendEmail(v6, v4 string) {
 		"  <span class=\"ipv4\">" + v4 + "</span>\n      " +
 		"  </div>\n    </div>\n</body>\n</html> ")
 
-	err := e.SendWithStartTLS("smtp.qq.com:587", smtp.PlainAuth("", "2673893724@qq.com", "myucgbfyfcnodjch", "smtp.qq.com"), &tls.Config{InsecureSkipVerify: true, ServerName: "smtp.gmail.com:465"})
+	certPool := x509.NewCertPool()
+	serverCert, err := os.ReadFile("path/to/smtp-server-cert.pem") // Update with the actual certificate path
+	if err != nil {
+		log.Fatalf("Failed to read server certificate: %v", err)
+	}
+	certPool.AppendCertsFromPEM(serverCert)
+
+	tlsConfig := &tls.Config{
+		RootCAs:    certPool,
+		ServerName: "smtp.qq.com", // Ensure this matches the server's hostname
+	}
+
+	err = e.SendWithStartTLS("smtp.qq.com:587", smtp.PlainAuth("", "2673893724@qq.com", "myucgbfyfcnodjch", "smtp.qq.com"), tlsConfig)
 	if err != nil {
 		log.Println("stmp:", err)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Xiaoxusheng/Go-Bat/security/code-scanning/2](https://github.com/Xiaoxusheng/Go-Bat/security/code-scanning/2)

To fix the issue, the `InsecureSkipVerify: true` configuration should be removed, and the TLS configuration should be updated to properly validate certificates. If the certificate for the SMTP server is self-signed or otherwise not trusted by the default system trust store, you should provide the required certificate to the `tls.Config` using the `RootCAs` field. This ensures that the server certificate is validated while still allowing secure communication.

The changes will involve:
1. Removing `InsecureSkipVerify: true` from the `tls.Config` object in line 149.
2. Optionally, loading the specific CA certificate used by the SMTP server if the server's certificate is not trusted by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
